### PR TITLE
handle non-existing security_definitions during serialization

### DIFF
--- a/src/spec/mod.rs
+++ b/src/spec/mod.rs
@@ -166,7 +166,7 @@ pub struct Swagger {
     pub paths: Paths,
     pub definitions: Definitions,
     pub responses: Responses,
-    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub security_definitions: BTreeMap<String, SecurityScheme>,
     pub security: Option<Vec<openapi::SecurityRequirement>>,
     pub tags: Option<Vec<openapi::Tag>>,

--- a/src/spec/mod.rs
+++ b/src/spec/mod.rs
@@ -164,8 +164,8 @@ pub struct Swagger {
     pub consumes: Option<Vec<String>>,
     pub produces: Option<Vec<String>>,
     pub paths: Paths,
-    pub definitions: Definitions,
-    pub responses: Responses,
+    pub definitions: Option<Definitions>,
+    pub responses: Option<Responses>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub security_definitions: BTreeMap<String, SecurityScheme>,
     pub security: Option<Vec<openapi::SecurityRequirement>>,
@@ -175,10 +175,18 @@ pub struct Swagger {
 
 impl From<Swagger> for openapi::OpenApi {
     fn from(swagger: Swagger) -> Self {
-        let responses: openapi::Responses = swagger.responses.into();
+        let responses: openapi::Responses = if swagger.responses.is_some() {
+            swagger.responses.unwrap().into()
+        } else {
+            openapi::Responses::new()
+        };
 
         let mut components = openapi::Components::new();
-        components.schemas = swagger.definitions.into();
+        components.schemas = if swagger.definitions.is_some() {
+            swagger.definitions.unwrap().into()
+        } else {
+            BTreeMap::new()
+        };
         components.responses = responses.responses;
         components.security_schemes = swagger
             .security_definitions


### PR DESCRIPTION
Regarding the [OpenAPI 2.0 Specification](https://swagger.io/specification/v2/#specification), 
- `securityDefinitions` are optional. So they need to be serialized as empty if non-existent
- `definitions` and `responses` are also optional